### PR TITLE
Add agenticSeek local CLI

### DIFF
--- a/agenticSeek/Makefile
+++ b/agenticSeek/Makefile
@@ -1,0 +1,7 @@
+.PHONY: install test
+
+install:
+	pip install .
+
+test:
+	pytest -q --cov=agentic_seek --cov-fail-under=80

--- a/agenticSeek/README.md
+++ b/agenticSeek/README.md
@@ -1,0 +1,37 @@
+# agenticSeek
+
+A lightweight command line tool for planning tasks and answering coding questions using a local language model accelerated on Apple Silicon.
+
+## Installation (Apple M1/M2)
+
+1. Install dependencies with Homebrew:
+
+```bash
+brew install python3 git
+```
+
+2. Clone this repository and install the package:
+
+```bash
+pip install .
+```
+
+3. Download a quantized LLM (for example, a llama.cpp model) and set `AGENTIC_SEEK_MODEL` to its path.
+
+## Running the Local LLM
+
+The project expects a local backend such as `llama.cpp` compiled with Metal or Accelerate. Set up the backend separately and ensure the `generate` function in `agentic_seek.__init__` invokes it. By default the package returns an echo of your prompt.
+
+## Usage
+
+```bash
+agentic-seek plan "organize my tasks"
+agentic-seek codex "how to write a list comprehension in Python?"
+```
+
+### Troubleshooting
+
+If you encounter `Makefile:*** missing separator` when running `make install`, ensure each command line in the Makefile starts with a **TAB** character.
+
+If your shell reports `agentic-seek: command not found`, run `pip install .` again and verify that your Python `bin` directory is in `PATH`.
+

--- a/agenticSeek/setup.py
+++ b/agenticSeek/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='agenticSeek',
+    version='0.1.0',
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    entry_points={
+        'console_scripts': ['agentic-seek=agentic_seek.cli:main']
+    },
+)
+

--- a/agenticSeek/src/agentic_seek/__init__.py
+++ b/agenticSeek/src/agentic_seek/__init__.py
@@ -1,0 +1,14 @@
+__all__ = ["generate", "__version__"]
+
+__version__ = "0.1.0"
+
+# placeholder generate function to be replaced by user-provided LLM integration
+
+def generate(prompt: str, **kwargs) -> str:
+    """Generate text from local model.
+
+    This minimal implementation simply echoes the prompt. Replace this
+    with a call into your local LLM backend, such as llama.cpp or GPT4All.
+    """
+    return f"Echo: {prompt}"
+

--- a/agenticSeek/src/agentic_seek/cli.py
+++ b/agenticSeek/src/agentic_seek/cli.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+from .codex_assistant import ask_codex
+from .llm_adapter import LLMAdapter
+from .reasoning import generate_with_reasoning
+
+
+def suggest_fix(error_message: str) -> Optional[str]:
+    if "missing separator" in error_message:
+        return "Makefile commands need to start with a TAB character."
+    if "command not found" in error_message and "agentic-seek" in error_message:
+        return "Run `pip install .` and ensure your PATH includes the Python scripts directory."
+    return None
+
+
+def main(argv: list[str] | None = None) -> str:
+    parser = argparse.ArgumentParser(prog="agentic-seek")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_plan = sub.add_parser("plan", help="Generate a plan from a prompt")
+    p_plan.add_argument("prompt")
+
+    p_codex = sub.add_parser("codex", help="Ask coding questions")
+    p_codex.add_argument("question")
+
+    args = parser.parse_args(argv)
+
+    adapter = LLMAdapter()
+    try:
+        if args.command == "plan":
+            return generate_with_reasoning(args.prompt, stream=True)
+        if args.command == "codex":
+            return ask_codex(args.question, stream=True)
+    except Exception as exc:  # pragma: no cover - truly unexpected
+        msg = str(exc)
+        fix = suggest_fix(msg)
+        if fix:
+            print(f"Suggestion: {fix}")
+        raise
+    return ""
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/agenticSeek/src/agentic_seek/codex_assistant.py
+++ b/agenticSeek/src/agentic_seek/codex_assistant.py
@@ -1,0 +1,12 @@
+from .reasoning import generate_with_reasoning
+
+CODEX_SYSTEM_PROMPT = (
+    "You are Codex, a helpful coding assistant. Provide concise answers and "
+    "relevant code snippets."
+)
+
+
+def ask_codex(question: str, stream: bool = False, **kwargs) -> str:
+    prompt = f"{CODEX_SYSTEM_PROMPT}\n\nQuestion:\n{question}\n\nAnswer:"
+    return generate_with_reasoning(prompt, stream=stream, **kwargs)
+

--- a/agenticSeek/src/agentic_seek/llm_adapter.py
+++ b/agenticSeek/src/agentic_seek/llm_adapter.py
@@ -1,0 +1,28 @@
+import os
+import platform
+from . import generate
+
+
+def is_apple_m_chip() -> bool:
+    """Return True if running on Apple Silicon."""
+    return platform.system() == "Darwin" and platform.machine().startswith("arm")
+
+
+class LLMAdapter:
+    """Adapter that loads a local LLM optimized for Apple Silicon."""
+
+    def __init__(self, model_path: str | None = None) -> None:
+        self.model_path = model_path or os.environ.get("AGENTIC_SEEK_MODEL", "model.bin")
+        self.loaded = False
+
+    def load(self) -> None:
+        if not is_apple_m_chip():
+            raise RuntimeError("LLMAdapter requires Apple Silicon (M-chip)")
+        # Loading of the quantized model would happen here, using accelerate/metal
+        self.loaded = True
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        if not self.loaded:
+            self.load()
+        return generate(prompt, **kwargs)
+

--- a/agenticSeek/src/agentic_seek/reasoning.py
+++ b/agenticSeek/src/agentic_seek/reasoning.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from . import generate
+
+LOG_FILE = Path(".cot.log")
+
+
+def log_step(text: str) -> None:
+    with LOG_FILE.open("a") as f:
+        f.write(f"[{datetime.now().isoformat()}] {text}\n")
+
+
+def generate_with_reasoning(prompt: str, stream: bool = False, **kwargs) -> str:
+    """Call :func:`generate` while logging chain-of-thought steps."""
+    log_step(f"PROMPT: {prompt}")
+    output = generate(prompt, **kwargs)
+    log_step(f"OUTPUT: {output}")
+    if stream:
+        print(output)
+    return output
+

--- a/agenticSeek/tests/test_cli.py
+++ b/agenticSeek/tests/test_cli.py
@@ -1,0 +1,37 @@
+import builtins
+
+import pytest
+
+from agentic_seek.cli import main, suggest_fix
+
+
+def test_suggest_fix_makefile():
+    fix = suggest_fix("Makefile:4: *** missing separator. Stop.")
+    assert "TAB" in fix
+
+
+def test_main_plan(monkeypatch, capsys):
+    called = {}
+
+    def fake_gen(prompt, stream=True):
+        called['prompt'] = prompt
+        if stream:
+            print('out')
+        return 'out'
+
+    monkeypatch.setattr('agentic_seek.cli.generate_with_reasoning', fake_gen)
+    main(['plan', 'hello'])
+    assert called['prompt'] == 'hello'
+    assert 'out' in capsys.readouterr().out
+
+
+def test_main_codex(monkeypatch, capsys):
+    def fake_codex(question, stream=True):
+        if stream:
+            print('code')
+        return 'code'
+
+    monkeypatch.setattr('agentic_seek.cli.ask_codex', fake_codex)
+    main(['codex', 'how to?'])
+    assert 'code' in capsys.readouterr().out
+

--- a/agenticSeek/tests/test_codex_assistant.py
+++ b/agenticSeek/tests/test_codex_assistant.py
@@ -1,0 +1,16 @@
+from agentic_seek.codex_assistant import ask_codex, CODEX_SYSTEM_PROMPT
+
+
+def test_ask_codex(monkeypatch):
+    captured = {}
+
+    def fake_generate(prompt, stream=False, **kwargs):
+        captured['prompt'] = prompt
+        return 'code'
+
+    monkeypatch.setattr('agentic_seek.codex_assistant.generate_with_reasoning', fake_generate)
+    out = ask_codex('How?', stream=False)
+    assert CODEX_SYSTEM_PROMPT in captured['prompt']
+    assert 'How?' in captured['prompt']
+    assert out == 'code'
+

--- a/agenticSeek/tests/test_llm_adapter.py
+++ b/agenticSeek/tests/test_llm_adapter.py
@@ -1,0 +1,18 @@
+from agentic_seek.llm_adapter import LLMAdapter, is_apple_m_chip
+
+
+def test_is_apple_m_chip_type():
+    assert isinstance(is_apple_m_chip(), bool)
+
+
+def test_llm_adapter_generate(monkeypatch):
+    adapter = LLMAdapter()
+    monkeypatch.setattr(adapter, 'load', lambda: None)
+
+    def fake_generate(prompt, **kwargs):
+        return 'response'
+
+    monkeypatch.setattr('agentic_seek.llm_adapter.generate', fake_generate)
+    out = adapter.generate('test')
+    assert out == 'response'
+


### PR DESCRIPTION
## Summary
- implement new `agenticSeek` package with local LLM wrapper
- support `plan` and new `codex` commands
- log reasoning steps to `.cot.log`
- detect common CLI errors and suggest fixes
- add Makefile, README, and setup script
- include unit tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bb25816ac8324b91272b5e46196ee