### PR TITLE
Fix Makefile separators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: install test
 
 install:
-brew bundle --file Brewfile
-pip install -e .
-./scripts/setup_local_llm.sh
+	brew bundle --file Brewfile
+	pip install -e .
+	./scripts/setup_local_llm.sh
 
 test:
-pytest --cov=src/agentic_seek -q
+	pytest --cov=src/agentic_seek -q


### PR DESCRIPTION
## Summary
- use tab separators in the Makefile

## Testing
- `make install` *(fails: brew command missing)*
- `make test` *(fails: pytest coverage arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685bb55ccd108324bc9a4fbcbe132eab